### PR TITLE
Add the ability to make classes without new

### DIFF
--- a/src/CustomTableCard.php
+++ b/src/CustomTableCard.php
@@ -3,9 +3,12 @@
 namespace Mako\CustomTableCard;
 
 use Laravel\Nova\Card;
+use Laravel\Nova\Makeable;
 
 class CustomTableCard extends Card
 {
+    use Makeable;
+
     public static $instanceCount = 0;
 
     /**

--- a/src/Table/Cell.php
+++ b/src/Table/Cell.php
@@ -2,10 +2,13 @@
 
 namespace Mako\CustomTableCard\Table;
 
+use Laravel\Nova\Makeable;
 use Mako\CustomTableCard\ToArrayInterface;
 
 class Cell implements ToArrayInterface
 {
+    use Makeable;
+
     public $data;
 
     public $classes = null;

--- a/src/Table/Row.php
+++ b/src/Table/Row.php
@@ -2,10 +2,13 @@
 
 namespace Mako\CustomTableCard\Table;
 
+use Laravel\Nova\Makeable;
 use Mako\CustomTableCard\ToArrayInterface;
 
 class Row implements ToArrayInterface
 {
+    use Makeable;
+
     public $columns;
 
     public $viewLink;


### PR DESCRIPTION
In some cases, it is more convenient not to wrap the initialization of the class in parentheses for the method call.

Your example **before**:
```php
// ...
public function cards()
{
    return [
        // ...

        // all the parameters are required except title
        (new \Mako\CustomTableCard\CustomTableCard)
            ->header([
                new \Mako\CustomTableCard\Table\Cell('Order Number'),
                (new \Mako\CustomTableCard\Table\Cell('Price'))->class('text-right'),
            ])
            ->data([
                (new \Mako\CustomTableCard\Table\Row(
                    new \Mako\CustomTableCard\Table\Cell('2018091001'),
                    (new \Mako\CustomTableCard\Table\Cell('20.50'))->class('text-right')->id('price-2')
                ))->viewLink('/resources/orders/1'),
                (new \Mako\CustomTableCard\Table\Row(
                    new \Mako\CustomTableCard\Table\Cell('2018091002'),
                    (new \Mako\CustomTableCard\Table\Cell('201.25'))->class('text-right')->id('price-2')
                )),
            ])
            ->title('Orders')
            ->viewall(['label' => 'View All', 'link' => '/resources/orders']),
    ];
}
```

Your example **after**:
```php
// ...
public function cards()
{
    return [
        // ...

        // all the parameters are required except title
        \Mako\CustomTableCard\CustomTableCard::make()
            ->header([
                \Mako\CustomTableCard\Table\Cell::make('Order Number'),
                \Mako\CustomTableCard\Table\Cell::make('Price')->class('text-right'),
            ])
            ->data([
                \Mako\CustomTableCard\Table\Row::make(
                    \Mako\CustomTableCard\Table\Cell::make('2018091001'),
                    \Mako\CustomTableCard\Table\Cell::make('20.50')->class('text-right')->id('price-2')
                )->viewLink('/resources/orders/1'),
                \Mako\CustomTableCard\Table\Row::make(
                    \Mako\CustomTableCard\Table\Cell::make('2018091002'),
                    \Mako\CustomTableCard\Table\Cell::make('201.25')->class('text-right')->id('price-2')
                ),
            ])
            ->title('Orders')
            ->viewall(['label' => 'View All', 'link' => '/resources/orders']),
    ];
}
```

Example with use (the code is cleaner):
```php
use Mako\CustomTableCard\CustomTableCard;
use Mako\CustomTableCard\Table\Cell;
use Mako\CustomTableCard\Table\Row;

// ...
public function cards()
{
    return [
        // ...

        // all the parameters are required except title
        CustomTableCard::make()
            ->header([
                Cell::make('Order Number'),
                Cell::make('Price')->class('text-right'),
            ])
            ->data([
                Row::make(
                    Cell::make('2018091001'),
                    Cell::make('20.50')->class('text-right')->id('price-2')
                )->viewLink('/resources/orders/1'),
                Row::make(
                    Cell::make('2018091002'),
                    Cell::make('201.25')->class('text-right')->id('price-2')
                ),
            ])
            ->title('Orders')
            ->viewall(['label' => 'View All', 'link' => '/resources/orders']),
    ];
}
```

The PR is backward compatible, does not break old code. Give the opportunity to use both options 
